### PR TITLE
Support Scala 3.5.0 and 3.4.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala:
+          - 3.5.0
+          - 3.4.3
           - 3.4.2
           - 3.4.1
           - 3.4.0
@@ -90,7 +92,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.4.2]
+        scala: [3.5.0]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -117,6 +119,26 @@ jobs:
             ~/AppData/Local/Coursier/Cache/v1
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Download target directories (3.5.0)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.5.0-${{ matrix.java }}
+
+      - name: Inflate target directories (3.5.0)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.4.3)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.4.3-${{ matrix.java }}
+
+      - name: Inflate target directories (3.4.3)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
 
       - name: Download target directories (3.4.2)
         uses: actions/download-artifact@v2

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,8 @@ inThisBuild(Seq(
   organization := "com.github.ghik",
   scalaVersion := crossScalaVersions.value.head,
   crossScalaVersions := Seq(
-    "3.4.2", "3.4.1", "3.4.0",
+    "3.5.0",
+    "3.4.3", "3.4.2", "3.4.1", "3.4.0",
     "3.3.3", "3.3.2", "3.3.1", "3.3.0",
     "3.2.2", "3.2.1",
     "2.13.10", "2.13.11", "2.13.12", "2.13.13", "2.13.14",

--- a/src/main/scala-3/com/github/ghik/zerowaste/ZerowastePlugin.scala
+++ b/src/main/scala-3/com/github/ghik/zerowaste/ZerowastePlugin.scala
@@ -15,7 +15,7 @@ class ZerowastePlugin extends StandardPlugin {
   def name = "zerowaste"
   def description = "Scala compiler plugin that disallows discarding of non-Unit expressions"
 
-  def init(options: List[String]): List[PluginPhase] =
+  override def init(options: List[String]): List[PluginPhase] =
     new ZerowastePhase :: Nil
 }
 


### PR DESCRIPTION
Added `override` modifier because since `3.5.0` missing modifier is an error:

```scala
[info] compiling 1 Scala source to /Users/martynas/projects/zerowaste/target/scala-3.5.0/classes ...
[error] -- [E164] Declaration Error: /Users/martynas/projects/zerowaste/src/main/scala-3/com/github/ghik/zerowaste/ZerowastePlugin.scala:18:6 
[error] 18 |  def init(options: List[String]): List[PluginPhase] =
[error]    |      ^
[error]    |error overriding method init in trait StandardPlugin of type (options: List[String]): List[dotty.tools.dotc.plugins.PluginPhase];
[error]    |  method init of type (options: List[String]): List[dotty.tools.dotc.plugins.PluginPhase] needs `override` modifier
[error] one error found
[error] Total time: 3 s, completed Aug 28, 2024, 3:20:41 PM
[error] (Compile / compileIncremental) Compilation failed
```