### PR TITLE
Scala 3.6.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.6.2, 3.5.2, 3.4.3, 3.3.4, 3.2.2, 2.13.16, 2.12.20]
+        scala: [3.6.3, 3.5.2, 3.4.3, 3.3.4, 3.2.2, 2.13.16, 2.12.20]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.6.2]
+        scala: [3.6.3]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -85,12 +85,12 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Download target directories (3.6.2)
+      - name: Download target directories (3.6.3)
         uses: actions/download-artifact@v4
         with:
-          name: target-${{ matrix.os }}-3.6.2-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.6.3-${{ matrix.java }}
 
-      - name: Inflate target directories (3.6.2)
+      - name: Inflate target directories (3.6.3)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ inThisBuild(Seq(
   organization := "com.github.ghik",
   scalaVersion := crossScalaVersions.value.head,
   crossScalaVersions := Seq(
-    "3.6.2", "3.5.2", "3.4.3", "3.3.4", "3.2.2", "2.13.16", "2.12.20",
+    "3.6.3", "3.5.2", "3.4.3", "3.3.4", "3.2.2", "2.13.16", "2.12.20",
   ),
 
   githubWorkflowTargetTags ++= Seq("v*"),


### PR DESCRIPTION
Maybe it would be possible to use back-publishing for new Scala verions? So plugin version does not change when new Scala version is out.

https://eed3si9n.com/back-publishing-actually/
https://github.com/sbt/sbt-ci-release?tab=readme-ov-file#back-publishing-support